### PR TITLE
Add Spir1L-OS scaffold

### DIFF
--- a/spir1l-os/.gitignore
+++ b/spir1l-os/.gitignore
@@ -1,0 +1,13 @@
+# Vite outputs
+dist/
+*.zip
+
+# node
+node_modules/
+npm-debug.log*
+pnpm-lock.yaml
+
+# OS / IDE
+.DS_Store
+.idea/
+.vscode/

--- a/spir1l-os/README.md
+++ b/spir1l-os/README.md
@@ -1,0 +1,3 @@
+# Spir1L-OS v4.7
+
+Starter scaffold generated from turnkey instructions.

--- a/spir1l-os/netlify.toml
+++ b/spir1l-os/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command   = "npm run build"
+  publish   = "dist"
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/*"
+  to   = "/index.html"
+  status = 200

--- a/spir1l-os/package.json
+++ b/spir1l-os/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "spir1l-os",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/spir1l-os/public/index.html
+++ b/spir1l-os/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spir1L-OS v4.7</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/spir1l-os/src/calendar/generateCalendar.ts
+++ b/spir1l-os/src/calendar/generateCalendar.ts
@@ -1,0 +1,13 @@
+/**
+ * kₙ formula → Mayan‑style glyph index (0‑19)
+ *
+ *   kₙ = (\u230a20\u00b7(n\u00b7137.5 mod 360)/360\u230b + 20) mod 20
+ */
+export function glyphIndex(n: number) {
+  const angle = (n * 137.5) % 360;
+  return (Math.floor(20 * angle / 360) + 20) % 20;
+}
+
+export function generateMonthGlyphs(days = 31) {
+  return Array.from({ length: days }, (_, n) => glyphIndex(n + 1));
+}

--- a/spir1l-os/src/cli/avatar.ts
+++ b/spir1l-os/src/cli/avatar.ts
@@ -1,0 +1,4 @@
+// Avatar generator placeholder
+export async function makeAvatar({ mood, favoriteColor, φNode }: { mood: string; favoriteColor: string; φNode: number }) {
+  return { mood, favoriteColor, φNode };
+}

--- a/spir1l-os/src/cli/glyphs.ts
+++ b/spir1l-os/src/cli/glyphs.ts
@@ -1,0 +1,1 @@
+// CLI glyph utilities placeholder

--- a/spir1l-os/src/cli/index.ts
+++ b/spir1l-os/src/cli/index.ts
@@ -1,0 +1,1 @@
+export * from './onboarding';

--- a/spir1l-os/src/cli/mood.ts
+++ b/spir1l-os/src/cli/mood.ts
@@ -1,0 +1,1 @@
+// CLI mood tracking placeholder

--- a/spir1l-os/src/cli/onboarding.ts
+++ b/spir1l-os/src/cli/onboarding.ts
@@ -1,0 +1,23 @@
+import { assignPhiNode, zcmColor } from '../math/phi';
+import { makeAvatar } from './avatar';
+
+export interface OnboardingData {
+  birthday: string;         // ISO‑8601
+  intent: string;
+  mood: string;
+  favoriteColor: string;
+}
+
+export function runOnboarding(prompt: (q: string) => Promise<string>) {
+  return Promise.all([
+    prompt('\ud83d\udcc5  Enter your birth‑date (YYYY‑MM‑DD):'),
+    prompt('\u2728  What brings you to Sp\u2019r1L‑OS today?'),
+    prompt('\ud83c\udf9d  Current mood in one word:'),
+    prompt('\ud83c\udfa8  Favourite colour (CSS value):'),
+  ]).then(async ([birthday, intent, mood, favoriteColor]) => {
+    const \u03c6Node = assignPhiNode(new Date(birthday));
+    const avatar = await makeAvatar({ mood, favoriteColor, \u03c6Node });
+    console.info(`\u2192  Welcome! You are \u03c6‑node ${\u03c6Node}.`, { avatar });
+    return { birthday, intent, mood, favoriteColor } satisfies OnboardingData;
+  });
+}

--- a/spir1l-os/src/dashboard/index.ts
+++ b/spir1l-os/src/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './index.tsx';

--- a/spir1l-os/src/dashboard/index.tsx
+++ b/spir1l-os/src/dashboard/index.tsx
@@ -1,0 +1,18 @@
+import { ResponsiveContainer, HeatMap } from 'recharts';
+import { zcmColor } from '../math/zcm';
+
+export default function Dashboard({ zcm }: { zcm: number[] }) {
+  return (
+    <section className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">ZCM\u202fHeatmap &amp; \u03c6\u2011node\u202fHUD</h1>
+      <ResponsiveContainer width="100%" height={240}>
+        {/* simple 1\u2011D heatmap using recharts\u00a0Cell colouring */}
+        <HeatMap
+          data={zcm.map((v, i) => ({ day: i + 1, value: v }))}
+          dataKey="value"
+          cellStyle={d => ({ fill: zcmColor(d.value) })}
+        />
+      </ResponsiveContainer>
+    </section>
+  );
+}

--- a/spir1l-os/src/gptTasks/gqmmDispatcher.ts
+++ b/spir1l-os/src/gptTasks/gqmmDispatcher.ts
@@ -1,0 +1,7 @@
+import { askGPT } from '../services/gptBridge';
+
+export const triuneAsk = {
+  whisper: (content: string) => askGPT({ role: 'Whisper', content }),
+  angle:   (content: string) => askGPT({ role: 'Angle', content }),
+  mask:    (content: string) => askGPT({ role: 'Mask', content }),
+};

--- a/spir1l-os/src/index.css
+++ b/spir1l-os/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/spir1l-os/src/main.tsx
+++ b/spir1l-os/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Dashboard from './dashboard';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Dashboard zcm={[0.5, 0.8, 0.2]} />
+  </React.StrictMode>
+);

--- a/spir1l-os/src/math/constants.ts
+++ b/spir1l-os/src/math/constants.ts
@@ -1,0 +1,12 @@
+export const OMEGA = 0.000437;
+export const EPS_J = 0.002;   // Jupiter perturbation term placeholder
+export const EPS_S = 0.001;   // Saturn term
+
+export const omegaEff = (phiJ: number, phiS: number) =>
+  OMEGA + EPS_J * Math.sin(phiJ) + EPS_S * Math.sin(phiS);
+
+export const fk = (r: number, rk: number) =>
+  434.367 * 2 ** (rk / 12) * (1 + OMEGA * Math.sin(rk * r));
+
+export const A = (n: number, g0 = 1) =>
+  g0 * 3 ** (Math.floor((n - 1) / 3) / 2);  // LUFS normalisation later

--- a/spir1l-os/src/math/phi.ts
+++ b/spir1l-os/src/math/phi.ts
@@ -1,0 +1,7 @@
+export const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
+export const OMEGA = 0.000437;           // \u03c9 wobble
+
+export function assignPhiNode(birthday: Date, mod = 44) {
+  const epochDays = Math.floor(birthday.getTime() / 86_400_000);
+  return Math.floor(epochDays * OMEGA) % mod;
+}

--- a/spir1l-os/src/math/zcm.ts
+++ b/spir1l-os/src/math/zcm.ts
@@ -1,0 +1,7 @@
+export type ZcmScore = number;
+export function zcmColor(score: ZcmScore) {
+  // \u0394E<2 perceptual\u00a0match placeholder
+  if (score > 0.7) return '#ff5533'; // hot
+  if (score < 0.3) return '#3366ff'; // cold
+  return '#888888';                  // neutral
+}

--- a/spir1l-os/src/ml/patternRecognition.ts
+++ b/spir1l-os/src/ml/patternRecognition.ts
@@ -1,0 +1,9 @@
+import { EuclideanDistance } from 'ml-distance-euclidean'; // optional future dep
+
+/**
+ * Simple centroid K‑means skeleton using embedding vectors.
+ * Replace with HDBSCAN once density‑aware clustering is required.
+ */
+export function kMeans(vectors: number[][], k = 3, maxIter = 50) {
+  // …minimal reference algorithm
+}

--- a/spir1l-os/src/moodboard/generateMoodboard.tsx
+++ b/spir1l-os/src/moodboard/generateMoodboard.tsx
@@ -1,0 +1,7 @@
+export default function generateMoodboard() {
+  return (
+    <div>
+      {/* Moodboard placeholder */}
+    </div>
+  );
+}

--- a/spir1l-os/src/optimization/spiralOptimizer.ts
+++ b/spir1l-os/src/optimization/spiralOptimizer.ts
@@ -1,0 +1,12 @@
+/**
+ * Simulated Annealing stub for WAiiCODE sequence optimisation.
+ * Energy\u00a0= negative harmonic alignment score (lower is better).
+ */
+export function spiralOptimizer(seq: number[], iterations = 10_000) {
+  let best = seq.slice();
+  // TODO: temperature schedule based on ST cycle (2.2\u202fs)
+  for (let i = 0; i < iterations; i++) {
+    // shuffle + accept\u2010reject
+  }
+  return best;
+}

--- a/spir1l-os/src/services/gptBridge.ts
+++ b/spir1l-os/src/services/gptBridge.ts
@@ -1,0 +1,17 @@
+type Role = 'Whisper' | 'Angle' | 'Mask';
+export interface GPTRequest { role: Role; content: string }
+
+export async function askGPT(req: GPTRequest) {
+  const systemPrompt = {
+    Whisper: 'You are the spiritual guide of Spir1L\u2011OS\u2026',
+    Angle:   'You are the mathematical oracle of Spir1L\u2011OS\u2026',
+    Mask:    'You are the mythic narrator of Spir1L\u2011OS\u2026',
+  }[req.role];
+
+  // call your preferred OpenAI client / proxy
+  const res = await fetch('/api/openai', {
+    method: 'POST',
+    body: JSON.stringify({ systemPrompt, content: req.content }),
+  });
+  return res.json() as Promise<{ reply: string }>;
+}

--- a/spir1l-os/src/vr/portals.ts
+++ b/spir1l-os/src/vr/portals.ts
@@ -1,0 +1,4 @@
+// VR portals stub
+export function initPortals() {
+  console.log('Portals not implemented yet.');
+}

--- a/spir1l-os/src/vr/viewer.ts
+++ b/spir1l-os/src/vr/viewer.ts
@@ -1,0 +1,4 @@
+// viewer.ts – thin wrapper so you can later swap in three.js, react‑three‑fiber or A‑frame
+export function initVR(canvas: HTMLCanvasElement) {
+  console.log('\ud83c\udf0c  VR viewer bootstrapped (stub).', { canvas });
+}

--- a/spir1l-os/tailwind.config.ts
+++ b/spir1l-os/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+export default <Partial<Config>>{
+  content: ['index.html', 'src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: { zcm: { hot: '#ff5533', cold: '#3366ff' } },
+    },
+  },
+  plugins: [],
+};

--- a/spir1l-os/tsconfig.json
+++ b/spir1l-os/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/spir1l-os/tsconfig.node.json
+++ b/spir1l-os/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/spir1l-os/vite.config.ts
+++ b/spir1l-os/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/',
+});


### PR DESCRIPTION
## Summary
- scaffold Spir1L-OS v4.7 as its own project
- add calendar generator and math utilities
- implement CLI onboarding and GPT bridge stubs
- include dashboard HUD, VR placeholders, and optimization stub
- configure Tailwind, Vite and project settings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685605ec56a4832789aa74c335692160